### PR TITLE
make div scrollbars invisible on Firefox

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -82,6 +82,7 @@ body {
 /* Div Styles */
 div {
   overflow: scroll;
+  scrollbar-width: none;
 }
 
 div.inlineScrollable {
@@ -96,6 +97,7 @@ div.paddedContainer {
 .col {
   padding: 0px;
   overflow: scroll;
+  scrollbar-width: none;
   display: flex;
   flex-direction: column;
   margin: 2px;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1430130/88844158-29a55c00-d1da-11ea-858a-9498f6b3346b.png)
scrollbars visible everywhere on Firefox 
just a couple of css additions to remove these